### PR TITLE
#18 feat: 미세먼지 위젯 디자인 수정(결과에 따른 배경색 지정)

### DIFF
--- a/src/components/Weather/Dust.jsx
+++ b/src/components/Weather/Dust.jsx
@@ -1,34 +1,55 @@
 /* 미세먼지 위젯 */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import '../../styles/weather/Dust.scss';
 
+// 서울시 미세먼지 API
 const DUST_API = {
   key: process.env.REACT_APP_DUST_API,
-  base: 'api.odcloud.kr/api',
+  base: '',
 };
 
 export default function Dust() {
   const [error, setError] = useState('');
+  const [dustGrade, setDustGrade] = useState('');
+  const [place, setPlace] = useState('');
+  const [bgClass, setBgClass] = useState('');
 
+  useEffect(() => {
+    getDust();
+  });
+
+  // 데이터 불러오기
   const getDust = () => {
-    let now = new Date();
-    let date = now.getDate();
-
-    let url = `https://api.odcloud.kr/api/MinuDustFrcstDspthSvrc/v1/getMinuDustFrcstDspth?searchDate=${date}&serviceKey=${DUST_API.key}`;
+    let url = `http://openAPI.seoul.go.kr:8088/${DUST_API.key}/json/RealtimeCityAir/1/25/`;
     fetch(url)
       .then((response) => response.json())
       .then((data) => {
-        console.log(data);
+        // 서울시 25개 지역구 중에 강동구만 추출
+        const gangdongData = data.RealtimeCityAir.row[24];
+        setPlace(gangdongData.MSRSTE_NM);
+        setDustGrade(gangdongData.IDEX_NM);
+
+        // 미세먼지 정도에 따라 다른 배경색 지정
+        if (gangdongData.IDEX_NM === '좋음') {
+          setBgClass('good');
+        } else if (gangdongData.IDEX_NM === '보통') {
+          setBgClass('normal');
+        } else {
+          setBgClass('bad');
+        }
       })
       .catch((error) => setError('ERROR'));
   };
-  // 콜백주소 https://api.odcloud.kr/api/MinuDustFrcstDspthSvrc/v1/getMinuDustFrcstDspth50Over
-
-  const DustBox = () => {};
 
   return (
-    <div>
-      <DustBox></DustBox>
+    <div className={`dust-box ${bgClass}`}>
+      <div className="dust-info">
+        오늘의 미세먼지 현황
+        <br />
+        <div className="dust-place">{place}</div>
+        <div className="dust-grade">{dustGrade}</div>
+      </div>
       {error && <div>{error}</div>}
     </div>
   );

--- a/src/styles/weather/Dust.scss
+++ b/src/styles/weather/Dust.scss
@@ -1,1 +1,49 @@
 // 미세먼지 위젯 스타일링
+@import '../root.scss';
+
+.dust-box {
+  width: 25rem;
+  height: 15rem;
+  position: relative;
+  text-align: center;
+  border: 1px solid $potato-beige;
+  border-radius: 12px;
+  margin-top: 4rem;
+  padding: 50px;
+  background-color: $chiliflower-white;
+
+  left: 80%; /* 부모 요소의 가로축 이동 */
+  transform: translate(-60%, -265%);
+  /* 위치 정렬 -> 이걸 지정하면 반응형 불가능 */
+
+  // 미세먼지 정도에 따라 다른 배경색 지정
+  &.good {
+    background-color: $romain-green;
+    color: $chiliflower-white;
+  }
+
+  &.normal {
+    background-color: $chiliflower-white;
+  }
+
+  &.bad {
+    background-color: $potato-beige;
+    color: $chiliflower-white;
+  }
+}
+
+.dust-info {
+  position: relative;
+  text-align: center;
+  line-height: 2.5rem;
+  font-size: 20px;
+  font-weight: 700;
+}
+.dust-place {
+  font-size: 16px;
+  font-weight: 300;
+}
+.dust-grade {
+  font-size: 36px;
+  font-weight: 900;
+}


### PR DESCRIPTION
- 서울 강동구 결과만 표시
- 미세먼지 결과 : 좋음, 보통, 나쁨으로 표시

> - 좋음 : 
배경색 : 로메인 그린; 
폰트 컬러 : 고추꽃 화이트;

> - 보통 : 
배경색 : 고추꽃 화이트;
border : 감자 베이지;

> - 나쁨 :
배경색 : 감자 베이지;
폰트 컬러 : 고추꽃 화이트;
